### PR TITLE
include headers for dist tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,14 @@ tex3ds_SOURCES = source/atlas.cpp \
                  source/magick_compat.cpp \
                  source/main.cpp \
                  source/rg_etc1.cpp \
-                 source/rle.cpp
+                 source/rle.cpp \
+                 include/atlas.h \
+                 include/compress.h \
+                 include/encode.h \
+                 include/magick_compat.h \
+                 include/quantum.h \
+                 include/rg_etc1.h \
+                 include/subimage.h
 
 tex3ds_LDADD = $(ImageMagick_LIBS)
 AM_CPPFLAGS   = -I$(srcdir)/include -D_GNU_SOURCE $(ImageMagick_CFLAGS)


### PR DESCRIPTION
Need to include the headers in Makefile.am or dist tarball won't include them.